### PR TITLE
Add file name to error message when a file can't be written

### DIFF
--- a/src/JasperFx.RuntimeCompiler/CodeFileExtensions.cs
+++ b/src/JasperFx.RuntimeCompiler/CodeFileExtensions.cs
@@ -145,7 +145,7 @@ namespace JasperFx.RuntimeCompiler
             }
             catch (Exception e)
             {
-                Console.WriteLine("Unable to write code file");
+                Console.WriteLine("Unable to write code file for " + file.FileName);
                 Console.WriteLine(e.ToString());
             }  
         }


### PR DESCRIPTION
Log file name when file is unable to be written.

Our services don't have access to write files, so we get this error when a generated code is missing. Typically, we forgot to get it registered, so the question is just what did we forget to register, but hopefully, this help us.