### PR TITLE
Add net9.0 target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <VersionPrefix>3.6.0</VersionPrefix>
     <LangVersion>10.0</LangVersion>
     <Authors>Jeremy D. Miller;Babu Annamalai;Oskar Dudycz;Joona-Pekka Kokko</Authors>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
     <DebugType>portable</DebugType>
 
     <PackageIconUrl>https://raw.githubusercontent.com/JasperFx/JasperFx.Core/main/jasperfx-logo.jpg?raw=true</PackageIconUrl>

--- a/src/JasperFx.CodeGeneration.Commands/JasperFx.CodeGeneration.Commands.csproj
+++ b/src/JasperFx.CodeGeneration.Commands/JasperFx.CodeGeneration.Commands.csproj
@@ -11,7 +11,7 @@
     </ItemGroup>
 
     <ItemGroup>
-        <PackageReference Include="Oakton" Version="6.1.0" />
+        <PackageReference Include="Oakton" Version="6.2.0" />
     </ItemGroup>
 
 


### PR DESCRIPTION
Assumes [oakton/#103](https://github.com/JasperFx/oakton/pull/103) has merged and published as `6.2.0`. Let me know if it publishes as a different version and I'll update this PR.